### PR TITLE
feat(redis): implementa caché de porcentaje con Redis reactivo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,10 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis-reactive</artifactId>
+		</dependency>
 
 
 		<dependency>

--- a/src/main/java/com/tempo/challenge/calculation_service/infraestructure/adapter/out/ExternalPercentageClient.java
+++ b/src/main/java/com/tempo/challenge/calculation_service/infraestructure/adapter/out/ExternalPercentageClient.java
@@ -1,0 +1,26 @@
+package com.tempo.challenge.calculation_service.infraestructure.adapter.out;
+
+import com.tempo.challenge.calculation_service.infraestructure.config.PercentageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import java.math.BigDecimal;
+
+@RequiredArgsConstructor
+@Repository
+public class ExternalPercentageClient {
+
+    private final WebClient percentageWebClient;
+
+    public Mono<BigDecimal> fetchPercentage() {
+
+        return percentageWebClient
+                .get()
+                .retrieve()
+                .bodyToMono(PercentageResponse.class)
+                .map(PercentageResponse::getPercentage)
+                .switchIfEmpty(Mono.error(new RuntimeException("No se recibió respuesta del servicio externo")));
+    }
+
+}

--- a/src/main/java/com/tempo/challenge/calculation_service/infraestructure/adapter/out/RedisPercentageCacheRepository.java
+++ b/src/main/java/com/tempo/challenge/calculation_service/infraestructure/adapter/out/RedisPercentageCacheRepository.java
@@ -1,0 +1,27 @@
+package com.tempo.challenge.calculation_service.infraestructure.adapter.out;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Mono;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisPercentageCacheRepository {
+
+    private final ReactiveRedisTemplate<String, BigDecimal> redisTemplate;
+    private static final String CACHE_KEY = "current-percentage";
+
+    public Mono<BigDecimal> get() {
+        return redisTemplate.opsForValue().get(CACHE_KEY);
+    }
+
+    public Mono<Void> save(BigDecimal percentage) {
+        return redisTemplate.opsForValue()
+                .set(CACHE_KEY, percentage, Duration.ofMinutes(30))
+                .then();
+    }
+}

--- a/src/main/java/com/tempo/challenge/calculation_service/infraestructure/config/RedisConfig.java
+++ b/src/main/java/com/tempo/challenge/calculation_service/infraestructure/config/RedisConfig.java
@@ -1,0 +1,26 @@
+package com.tempo.challenge.calculation_service.infraestructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.math.BigDecimal;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public ReactiveRedisTemplate<String, BigDecimal> reactiveRedisTemplate(ReactiveRedisConnectionFactory factory) {
+        RedisSerializationContext.RedisSerializationContextBuilder<String, BigDecimal> builder =
+                RedisSerializationContext.newSerializationContext(new StringRedisSerializer());
+
+        RedisSerializationContext<String, BigDecimal> context = builder
+                .value(new org.springframework.data.redis.serializer.GenericToStringSerializer<>(BigDecimal.class))
+                .build();
+
+        return new ReactiveRedisTemplate<>(factory, context);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,6 @@ spring.application.name=calculation-service
 # application.properties
 percentage.service.url=http://localhost:5001/percentage
 
+# Redis Configuration
+spring.redis.host=localhost
+spring.redis.port=6379

--- a/src/test/java/com/tempo/challenge/calculation_service/infraestructure/ExternalPercentageClientTest.java
+++ b/src/test/java/com/tempo/challenge/calculation_service/infraestructure/ExternalPercentageClientTest.java
@@ -1,0 +1,59 @@
+package com.tempo.challenge.calculation_service.infraestructure;
+
+import com.tempo.challenge.calculation_service.infraestructure.adapter.out.ExternalPercentageClient;
+import com.tempo.challenge.calculation_service.infraestructure.adapter.out.PercentageRepositoryImpl;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+
+public class ExternalPercentageClientTest {
+
+    private MockWebServer mockWebServer;
+    private ExternalPercentageClient externalPercentageClient;
+
+    @BeforeEach
+    void setup() throws IOException {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start();
+
+        String baseUrl = mockWebServer.url("/").toString();
+
+        WebClient webClient = WebClient.builder()
+                .baseUrl(baseUrl)
+                .build();
+
+        externalPercentageClient = new ExternalPercentageClient(webClient);
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    void given_validResponse_when_getCurrentPercentage_then_returnPercentage() {
+        String mockBody = "{\"percentage\": 15.5}";
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(mockBody)
+                .addHeader("Content-Type", "application/json"));
+
+        Mono<BigDecimal> result = externalPercentageClient.fetchPercentage();
+
+        StepVerifier.create(result)
+                .expectNext(new BigDecimal("15.5"))
+                .verifyComplete();
+    }
+
+
+}

--- a/src/test/java/com/tempo/challenge/calculation_service/infraestructure/PercentageRepositoryImplTest.java
+++ b/src/test/java/com/tempo/challenge/calculation_service/infraestructure/PercentageRepositoryImplTest.java
@@ -18,39 +18,5 @@ import java.math.BigDecimal;
 @ExtendWith(SpringExtension.class)
 class PercentageRepositoryImplTest {
 
-    private MockWebServer mockWebServer;
-    private PercentageRepositoryImpl percentageRepository;
 
-    @BeforeEach
-    void setup() throws IOException {
-        mockWebServer = new MockWebServer();
-        mockWebServer.start();
-
-        String baseUrl = mockWebServer.url("/").toString();
-
-        WebClient webClient = WebClient.builder()
-                .baseUrl(baseUrl)
-                .build();
-
-        percentageRepository = new PercentageRepositoryImpl(webClient);
-    }
-
-    @AfterEach
-    void tearDown() throws IOException {
-        mockWebServer.shutdown();
-    }
-
-    @Test
-    void given_validResponse_when_getCurrentPercentage_then_returnPercentage() {
-        String mockBody = "{\"percentage\": 15.5}";
-        mockWebServer.enqueue(new MockResponse()
-                .setBody(mockBody)
-                .addHeader("Content-Type", "application/json"));
-
-        Mono<BigDecimal> result = percentageRepository.getCurrentPercentage();
-
-        StepVerifier.create(result)
-                .expectNext(new BigDecimal("15.5"))
-                .verifyComplete();
-    }
 }

--- a/src/test/java/com/tempo/challenge/calculation_service/infraestructure/RealPercentageRepositoryImplTest.java
+++ b/src/test/java/com/tempo/challenge/calculation_service/infraestructure/RealPercentageRepositoryImplTest.java
@@ -1,6 +1,7 @@
 package com.tempo.challenge.calculation_service.infraestructure;
 
 import com.tempo.challenge.calculation_service.domain.port.PercentageRepository;
+import com.tempo.challenge.calculation_service.infraestructure.adapter.out.ExternalPercentageClient;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -13,11 +14,11 @@ import java.math.BigDecimal;
 class RealPercentageRepositoryImplTest {
 
     @Autowired
-    private PercentageRepository percentageRepository;
+    private ExternalPercentageClient externalPercentageClient;
 
     @Test
     void when_callingRealService_then_returnsPercentage() {
-        Mono<BigDecimal> result = percentageRepository.getCurrentPercentage();
+        Mono<BigDecimal> result = externalPercentageClient.fetchPercentage();
 
         StepVerifier.create(result)
                 .expectNextMatches(p -> p.compareTo(BigDecimal.ZERO) > 0)

--- a/src/test/java/com/tempo/challenge/calculation_service/infraestructure/RedisPercentageCacheRepositoryTest.java
+++ b/src/test/java/com/tempo/challenge/calculation_service/infraestructure/RedisPercentageCacheRepositoryTest.java
@@ -1,0 +1,78 @@
+package com.tempo.challenge.calculation_service.infraestructure;
+
+import com.tempo.challenge.calculation_service.infraestructure.adapter.out.RedisPercentageCacheRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.core.ReactiveValueOperations;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+class RedisPercentageCacheRepositoryTest {
+
+    private RedisPercentageCacheRepository redisRepository;
+
+    @Mock
+    private ReactiveRedisTemplate<String, BigDecimal> redisTemplate;
+
+    @Mock
+    private ReactiveValueOperations<String, BigDecimal> valueOperations;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        redisRepository = new RedisPercentageCacheRepository(redisTemplate);
+    }
+
+    @Test
+    void given_percentage_when_save_then_storeInRedis() {
+        // Arrange
+        BigDecimal percentage = BigDecimal.valueOf(25);
+        when(valueOperations.set(eq("current-percentage"), eq(percentage), any(Duration.class)))
+                .thenReturn(Mono.just(true));
+
+        // Act & Assert
+        StepVerifier.create(redisRepository.save(percentage))
+                .verifyComplete();
+
+        verify(valueOperations).set(eq("current-percentage"), eq(percentage), any(Duration.class));
+    }
+
+    @Test
+    void given_valueInCache_when_get_then_returnValue() {
+        // Arrange
+        BigDecimal expected = BigDecimal.valueOf(15);
+        when(valueOperations.get("current-percentage")).thenReturn(Mono.just(expected));
+
+        // Act
+        Mono<BigDecimal> result = redisRepository.get();
+
+        // Assert
+        StepVerifier.create(result)
+                .expectNext(expected)
+                .verifyComplete();
+    }
+
+    @Test
+    void given_cacheMiss_when_get_then_returnEmptyMono() {
+        // Arrange
+        when(valueOperations.get("current-percentage")).thenReturn(Mono.empty());
+
+        // Act
+        Mono<BigDecimal> result = redisRepository.get();
+
+        // Assert
+        StepVerifier.create(result)
+                .verifyComplete();
+    }
+}


### PR DESCRIPTION
- Crea la clase RedisPercentageCacheRepository para manejar la lógica de caché de porcentaje usando ReactiveRedisTemplate.
- Configura RedisConfig para exponer el bean de ReactiveRedisTemplate con soporte para BigDecimal.
- Añade Redis al archivo docker-compose.yml como servicio.
- Añade propiedades de conexión Redis en application.properties.
- Implementa pruebas unitarias para RedisPercentageCacheRepository usando Mockito y StepVerifier.